### PR TITLE
Bug#1 : Handle the case when limit for fetching the list of users is 0.

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -173,23 +173,25 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
-    total_users = await UserService.count(db)
-    users = await UserService.list_users(db, skip, limit)
+    if limit>0:
+        total_users = await UserService.count(db)
+        users = await UserService.list_users(db, skip, limit)
 
-    user_responses = [
-        UserResponse.model_validate(user) for user in users
-    ]
-    
-    pagination_links = generate_pagination_links(request, skip, limit, total_users)
-    
-    # Construct the final response with pagination details
-    return UserListResponse(
-        items=user_responses,
-        total=total_users,
-        page=skip // limit + 1,
-        size=len(user_responses),
-        links=pagination_links  # Ensure you have appropriate logic to create these links
-    )
+        user_responses = [
+            UserResponse.model_validate(user) for user in users
+        ]
+        
+        pagination_links = generate_pagination_links(request, skip, limit, total_users)
+        
+        # Construct the final response with pagination details
+        return UserListResponse(
+            items=user_responses,
+            total=total_users,
+            page=skip // limit + 1,
+            size=len(user_responses),
+            links=pagination_links  # Ensure you have appropriate logic to create these links
+        )
+    raise HTTPException(status_code=400, detail="Limit must be greater than 0")
 
 
 @router.post("/register/", response_model=UserResponse, tags=["Login and Registration"])

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -184,6 +184,16 @@ async def test_list_users_as_manager(async_client, manager_token):
     assert response.status_code == 200
 
 @pytest.mark.asyncio
+async def test_list_users_0_pagination(async_client, admin_token):
+    response = await async_client.get(
+        "/users/?limit=0&skip=0",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 400
+    assert "Limit must be greater than 0" in response.json().get("detail", "")
+    
+
+@pytest.mark.asyncio
 async def test_list_users_unauthorized(async_client, user_token):
     response = await async_client.get(
         "/users/",


### PR DESCRIPTION
To resolve the issue causing an Internal Server Error when attempting to fetch a list of users with a pagination limit set to 0, the proposed solution includes two steps:

**Parameter Validation:** Before executing the request, we'll validate the pagination limit parameter. If the limit is greater than 0, the request will proceed as usual. However, if the limit is 0 or less, indicating an invalid pagination setting, the API will return a 400 Bad Request error along with a message "Limit must be greater than 0". This error message will specify that the limit parameter must be a positive integer.
**Clarification on Pagination Limit:** It's important to add a clarification that the limit of 0 is specifically related to pagination. Pagination limits typically indicate the maximum number of items to be displayed on each page of results. Therefore, setting the limit to 0 effectively disables pagination, resulting in an attempt to fetch an empty list of users. This clarification ensures that users understand the purpose and implications of the pagination limit parameter.
By implementing these changes, the API will handle pagination limits more robustly, ensuring that only valid values are accepted and preventing unexpected server errors caused by invalid input parameters.