### PR TITLE
Bug#6 Updated the code to be able to handle existing

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -88,6 +88,8 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
     """
     user_data = user_update.model_dump(exclude_unset=True)
     updated_user = await UserService.update(db, user_id, user_data)
+    if updated_user =="EMAIL_ALREADY_TAKEN":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Email address already taken")
     if not updated_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -85,7 +85,11 @@ class UserService:
         try:
             # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).model_dump(exclude_unset=True)
-
+            if "email" in validated_data.keys():
+                existing_user = await cls.get_by_email(session, validated_data['email'])
+                if existing_user and existing_user.id!=user_id:
+                    logger.error("User with given email already exists.")
+                    return "EMAIL_ALREADY_TAKEN"
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -183,6 +183,16 @@ async def test_delete_user_does_not_exist(async_client, admin_token):
     assert delete_response.status_code == 404
 
 @pytest.mark.asyncio
+async def test_update_user_email_duplicate_update_fail(async_client, admin_user,admin_token, unverified_user):
+    updated_data = {"email": f"updated_{admin_user.id}@example.com"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response1 = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
+    response2 = await async_client.put(f"/users/{unverified_user.id}", json=updated_data, headers=headers)
+    assert response1.status_code == 200
+    assert response2.status_code == 404
+    assert "Email address already taken" in response2.json().get("detail", "")
+
+@pytest.mark.asyncio
 async def test_update_user_github(async_client, admin_user, admin_token):
     updated_data = {"github_profile_url": "http://www.github.com/kaw393939"}
     headers = {"Authorization": f"Bearer {admin_token}"}

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -30,6 +30,24 @@ async def test_create_user_with_invalid_data(db_session, email_service):
     user = await UserService.create(db_session, user_data, email_service)
     assert user is None
 
+async def test_create_user_with_same_email(db_session, email_service):
+    user_data1 = {
+        "nickname": generate_nickname(),
+        "email": "valid_user@example.com",
+        "password": "ValidPassword123!",
+        "role": UserRole.ADMIN.name
+    }
+    user1 = await UserService.create(db_session, user_data1, email_service)
+    assert user1.email == user_data1["email"]
+    user_data2 = {
+        "nickname": generate_nickname(),
+        "email": "valid_user@example.com",
+        "password": "ValidPassword123!",
+        "role": UserRole.ANONYMOUS.name
+    }
+    user2 = await UserService.create(db_session, user_data2, email_service)
+    assert user2 is None
+
 # Test fetching a user by ID when the user exists
 async def test_get_by_id_user_exists(db_session, user):
     retrieved_user = await UserService.get_by_id(db_session, user.id)


### PR DESCRIPTION
**Handle Duplicate Email Update for Users**
**Description:**

1. This PR addresses a bug in the user email update functionality. Previously, when attempting to update a user's email with an email address that already exists in the database for another user, the server would accept the request and return a 200 OK response, which is incorrect behavior.

**Bug Details:**
**Steps to reproduce:**

1. Create a user with the email abc@email.com using the /create API endpoint.
2. Create another user with the email xyz@email.com using the /create API endpoint.
3. Attempt to update the email of the first user to xyz@email.com using the /users/{user_id} API endpoint.
4. Expected behavior: The server should reject the request and return an appropriate error message, as the email address xyz@email.com is already associated with another user.

**Actual behavior:** 

1. The server accepts the request and returns a 200 OK response, allowing the email update to proceed, resulting in a duplicate email address in the database.

**Fix Implementation:**

1.  Added a check in the user email update functionality to verify if the provided email address already exists in the database for another user.
2. If the email address is found to be associated with another user, the server now returns a 404 Not Found response with the error message "Email address already taken."
3. Wrote a new test case test_update_user_email_duplicate_update_fail to ensure the correct behavior when attempting to update a user's email with an existing email address.